### PR TITLE
Move professional links to About Me page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,4 @@
 
 Cursor
 
-## Links
-
-- [LinkedIn](https://www.linkedin.com/in/indermeet/)
-- [Google Patents](https://patents.google.com/?inventor=indermeet+Gandhi&oq=inventor:(indermeet+Gandhi)&sort=new&dups=language)
-- [Google Scholar](https://scholar.google.com/citations?user=UKyyW5AAAAAJ&hl=en)
-- [Google Publications](https://patents.google.com/?inventor=indermeet+Gandhi&patents=false&scholar&oq=inventor:(indermeet+Gandhi)&sort=new&dups=language)
+For professional links, see the [About Me page](https://isga.github.io/inder-gandhi/).

--- a/inder-gandhi/index.md
+++ b/inder-gandhi/index.md
@@ -1,0 +1,15 @@
+# About Me
+
+I'm Inder Gandhi, an AI & cybersecurity innovator with over 16 years of experience turning ambiguous problems into market‑defining products. Named on more than 100 patents spanning AI, networking and cloud security, I've led multi‑product portfolios at startups and Fortune 500 companies and generated over $350 million in revenue.
+
+I began my career as a network engineer, building carrier‑grade 4G/5G infrastructure and resolving high‑severity escalations. Seeking to bridge deep technical expertise with market needs, I transitioned into product management and have since defined strategies and delivered solutions from concept through launch. My work ranges from pioneering the first AI Model Scanner and AI Bill of Materials (AI‑BOM) standard at Lineaje to scaling Cisco’s observability platform by 400 % and introducing subscription models that added $350 million in annual recurring revenue.
+
+Throughout my journey, I've learned the value of aligning cross‑functional teams, listening to customers and balancing bold innovation with pragmatic execution. I enjoy mentoring others, building high‑performing teams and creating products that make the digital world safer and smarter. Outside of work, I pursue continuous learning in AI, security and product leadership.
+
+## Professional Links
+
+- [LinkedIn](https://www.linkedin.com/in/indermeet/)
+- [Google Patents](https://patents.google.com/?inventor=indermeet+Gandhi&oq=inventor:(indermeet+Gandhi)&sort=new&dups=language)
+- [Google Scholar](https://scholar.google.com/citations?user=UKyyW5AAAAAJ&hl=en)
+- [Google Publications](https://patents.google.com/?inventor=indermeet+Gandhi&patents=false&scholar&oq=inventor:(indermeet+Gandhi)&sort=new&dups=language)
+


### PR DESCRIPTION
## Summary
- relocate professional links to the `inder-gandhi` page
- point README visitors to the new page

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687c17cd03608333a9a0d3d6f3687a68